### PR TITLE
Verify all data about the document whenever possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,15 @@ The QR content is in the structure:
 - A Base45 encoded signature (sig).
 These steps first convert the QR content from Base45, then decompress it, then extract out the signature to be decoded into a binary form used for verification:
 ```
-cat testqr.txt | base45 --decode | zlib-flate -uncompress | jq -r ".sig"  | base45 --decode > sig
+cat testqr.txt | base45 --decode | zlib-flate -uncompress | jq -r ".sig" | base45 --decode > sig
 ```
-5. Extact the fields from the QR code to verify against the signature (ensuring no trailing new line characters):
+5. Extact all fields except the signature from the QR code to verify against the signature file created above (ensuring no trailing new line characters):
 ```
-cat testqr.txt | base45 --decode | zlib-flate -uncompress | jq -r --compact-output ".f" | tr -d '\n' > data
+cat testqr.txt | base45 --decode | zlib-flate -uncompress | jq -r --compact-output "del(.sig)" | tr -d '\n' > data
+```
+The signature is created against the JSON format of all fields and metadata about the document. As a result, your data file should be a JSON file whose keys are in in the same order. e.g.
+```
+{"f":{"templatevariable":"a value"},"dId":"uuid of document","ver":"1.1.0","cdate":"2021-10-08","kid":"keyalias:keyversion"}
 ```
 6. Verify the field data signature:
 ```

--- a/app/src/main/java/au/gov/qld/bdm/documentproduction/document/SignedQRContent.java
+++ b/app/src/main/java/au/gov/qld/bdm/documentproduction/document/SignedQRContent.java
@@ -1,17 +1,31 @@
 package au.gov.qld.bdm.documentproduction.document;
 
+import java.util.Date;
+import java.util.Map;
 import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.joda.time.LocalDate;
 
 import com.google.gson.Gson;
 
 public class SignedQRContent {
 
-	private SortedMap<String, String> f;
+	private static final String VERSION = "1.1.0";
+
+	private final SortedMap<String, String> f;
+	private final String dId;
+	private final String ver;
+	private final String cdate;
 	private String sig;
 	private String kid;
-	private String dId;
-	private String ver;
-	private String cdate;
+
+	public SignedQRContent(String dId, Date createdDate, Map<String, String> f) {
+		this.dId = dId;
+		this.cdate = new LocalDate(createdDate).toString("yyyy-MM-dd");
+		this.f = new TreeMap<>(f);
+		this.ver = VERSION;
+	}
 
 	public SortedMap<String, String> getF() {
 		return f;
@@ -29,10 +43,6 @@ public class SignedQRContent {
 		return dId;
 	}
 
-	public void setF(SortedMap<String, String> f) {
-		this.f = f;
-	}
-
 	public void setSig(String sig) {
 		this.sig = sig;
 	}
@@ -41,28 +51,12 @@ public class SignedQRContent {
 		this.kid = kId;
 	}
 
-	public String getSignatureContent() {
-		return new Gson().toJson(f);
-	}
-
 	public String getAllContent() {
 		return new Gson().toJson(this);
 	}
 
-	public void setDId(String documentId) {
-		this.dId = documentId;
-	}
-
-	public void setVer(String ver) {
-		this.ver = ver;
-	}
-	
 	public String getVer() {
 		return ver;
-	}
-
-	public void setCDate(String cDate) {
-		this.cdate = cDate;
 	}
 	
 	public String getCDate() {

--- a/client/demo/src/components/VideoCapture.vue
+++ b/client/demo/src/components/VideoCapture.vue
@@ -18,7 +18,8 @@
       Fields: <b>{{ result.f }}</b><br/>
     </p>
     <button v-if="result != ''" @click="reset">Reset</button>
-    <p>Certificate</p>
+    <hr/>
+    <p>Verification certificate:</p>
     <textarea @change="onDecode" class="certificate" v-model="certificate"></textarea>
   </div>
 </template>
@@ -42,6 +43,9 @@ export default {
       processing: false
     }
   },
+  created() {
+    document.title = 'Demonstration client for QR verficiation'
+  },
   methods: {
     async onInit(promise) {
       try {
@@ -63,7 +67,8 @@ export default {
           this.result = JSON.parse(r)
           const signature = base45.decode(this.result.sig)
           const verifier = crypto.createVerify('rsa-sha256')
-          verifier.update(JSON.stringify(this.result.f))          
+          delete this.result.sig
+          verifier.update(JSON.stringify(this.result))
           this.verifyResult =  verifier.verify(this.certificate, signature, 'binary')
         })
       } catch(error) {


### PR DESCRIPTION
Verify all data about the document whenever possible.

This way the metadata can also be trusted, such as the document ID (used in future for verifying status of a document), when it was created, etc. This way a QR could not be fraudulently created with the same signature, but a different document ID, thus bypassing the verification of status of a document.

This should set us up to be able to query document status reliably in future.